### PR TITLE
Add support for more programming languages

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,19 +53,22 @@
 					"default": true,
 					"description": "Sort object after inserting translation."
 				},
-				"generate-translation.replaceOnTranslate": {
-					"type": "boolean",
-					"default": true,
-					"description": "Replace the selected text in HTML files after generating a translation string."
+				"generate-translation.replaceForLanguages": {
+					"type": "array",
+					"default": [
+						"html"
+					],
+					"description": "Define languages (html, javascript, vue, etc.) for which templateHtmlToReplace will be used."
 				},
-				"generate-translation.templateHtmlToReplace": {
+				"generate-translation.templateSnippetToReplace": {
 					"type": "string",
 					"default": "{{ 'i18n' | translate }}",
-					"description": "Template HTML to replace the selected text after generating a translation string. \n The string i18n will be replaced by the chosen key."
+					"description": "Template snippet to replace the selected text after generating a translation string. \n The string i18n will be replaced by the chosen key."
 				}
 			}
 		},
-		"commands": [{
+		"commands": [
+			{
 				"command": "generateTranslation.fromSelectedText",
 				"title": "Generate Translation: From selected text"
 			},

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -62,12 +62,12 @@ export abstract class GenerateTranslation {
 
   private static replaceOnTranslate(textSelection: string) {
     const editor = window.activeTextEditor;
-    const replaceOnTranslate = workspace.getConfiguration('generate-translation').get('replaceOnTranslate');
-    const templateHtmlToReplace = <string>workspace.getConfiguration('generate-translation').get('templateHtmlToReplace');
+    const replaceForLanguages = <Array<string>>workspace.getConfiguration('generate-translation').get('replaceForLanguages');
+    const templateSnippetToReplace = <string>workspace.getConfiguration('generate-translation').get('templateSnippetToReplace');
 
-    if (editor && replaceOnTranslate && templateHtmlToReplace && editor.document.languageId === 'html') {
+    if (editor && replaceForLanguages.indexOf(editor.document.languageId) > -1 && templateSnippetToReplace) {
       editor.edit(editBuilder => {
-        editBuilder.replace(editor.selection, templateHtmlToReplace.replace('i18n', textSelection));
+        editBuilder.replace(editor.selection, templateSnippetToReplace.replace('i18n', textSelection));
       });
     }
   }


### PR DESCRIPTION
Hey,

Thanks for that plugin. It's useful.

At the moment plugin replaces selected text only in html files.
This PR enables users of the plugin to define languages.